### PR TITLE
Render 'rawOutput' log field specially

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,10 +234,20 @@ func (p *processor) maybePrettyPrintZapLine(line string, lineData map[string]int
 		errorVerbose = t
 	}
 
+	rawOutput := ""
+	if t, ok := lineData["rawOutput"].(string); ok && t != "" {
+		delete(lineData, "rawOutput")
+		rawOutput = t
+	}
+
 	p.writeJSON(&buffer, lineData)
 
 	if stacktrace != "" {
 		p.writeErrorDetails(&buffer, errorVerbose, stacktrace)
+	}
+
+	if rawOutput != "" {
+		p.writeRawOutput(&buffer, rawOutput)
 	}
 
 	return buffer.String(), nil
@@ -401,6 +411,12 @@ func writeErrorVerbose(buffer *bytes.Buffer, errorVerbose string) {
 			buffer.WriteString(*lineCurrent)
 		}
 	}
+}
+
+func (p *processor) writeRawOutput(buffer *bytes.Buffer, rawOutput string) {
+	buffer.WriteString("\nRaw Output (from 'rawOutput')\n")
+	buffer.WriteString(rawOutput)
+	buffer.WriteString("\n-- EOF --")
 }
 
 func writeStackSectionTitle(buffer *bytes.Buffer, line string) {

--- a/signaler_others.go
+++ b/signaler_others.go
@@ -1,4 +1,5 @@
-//+build darwin linux
+//go:build darwin || linux
+// +build darwin linux
 
 package main
 


### PR DESCRIPTION
Example output after this patch:
```
[2023-02-16 18:19:43.656 IST] info (nirvana/main.go:8) Simple log line
[2023-02-16 18:19:43.656 IST] info (nirvana/main.go:9) Log line with some raw output
Raw Output (from 'rawOutput')
Line1
"Line2"
        Line3
-- EOF --
[2023-02-16 18:19:43.656 IST] info (nirvana/main.go:13) Another Simple log line
```
